### PR TITLE
grep: Default to -p instead of -S

### DIFF
--- a/tests/usr.bin/grep/t_grep.sh
+++ b/tests/usr.bin/grep/t_grep.sh
@@ -89,7 +89,7 @@ recurse_symlink_body()
 
 	atf_check -o file:"$(atf_get_srcdir)/d_recurse_symlink.out" \
 	    -e file:"$(atf_get_srcdir)/d_recurse_symlink.err" \
-	    grep -r string test
+	    grep -rS string test
 }
 
 atf_test_case word_regexps

--- a/usr.bin/grep/grep.c
+++ b/usr.bin/grep/grep.c
@@ -124,7 +124,7 @@ int	 binbehave = BINFILE_BIN;	/* -aIU: handling of binary files */
 int	 filebehave = FILE_STDIO;	/* -JZ: normal, gzip or bzip2 file */
 int	 devbehave = DEV_READ;		/* -D: handling of devices */
 int	 dirbehave = DIR_READ;		/* -dRr: handling of directories */
-int	 linkbehave = LINK_READ;	/* -OpS: handling of symlinks */
+int	 linkbehave = LINK_SKIP;	/* -OpS: handling of symlinks */
 
 bool	 dexclude, dinclude;	/* --exclude-dir and --include-dir */
 bool	 fexclude, finclude;	/* --exclude and --include */


### PR DESCRIPTION
This matches the documented behavior in the manpage as well as the default behavior on macOS.

---

FreeBSD PR:	280676
Reported by:	Radosław Piliszek <radoslaw.piliszek@gmail.com>